### PR TITLE
fix(build): export `instance` obviously

### DIFF
--- a/build.js
+++ b/build.js
@@ -42,11 +42,16 @@ const writeEntry = () =>
       `
 'use strict';
 
+var stack;
+
 if (process.env.NODE_ENV === 'production') {
-  module.exports = require('./cjs/event-stack.production.js');
+  stack = require('./cjs/event-stack.production.js');
 } else {
-  module.exports = require('./cjs/event-stack.development.js');
+  stack = require('./cjs/event-stack.development.js');
 }
+
+module.exports = stack.default;
+module.exports.instance = stack.instance;
 `,
       err => {
         if (err) reject(err)


### PR DESCRIPTION
This PR fixes a build with Rollup:

```
[!] Error: 'instance' is not exported by node_modules\@semantic-ui-react\event-stack\lib\index.js
https://rollupjs.org/guide/en#error-name-is-not-exported-by-module-
src\main.js (1:15)
1: import Stack, {instance} from '@semantic-ui-react/event-stack';
```

Also fixes issue reported in https://github.com/Semantic-Org/Semantic-UI-React/issues/3280.